### PR TITLE
usnic: Fix typo in EQ peek handling.

### DIFF
--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -299,7 +299,7 @@ usdf_eq_read_fd(struct fid_eq *feq, uint32_t *event, void *buf, size_t len,
 		goto done;
 	}
 
-	if ((flags & FI_PEEK) != 0) {
+	if ((flags & FI_PEEK) == 0) {
 		/* consume the event in eventfd */
 		ret = read(eq->eq_fd, &val, sizeof(val));
 		if (ret != sizeof(val)) {


### PR DESCRIPTION
FD should be cleared on a non-peek read.

@cb-benve @xuywang
I have not finished updating to libfabric 1.3, this problem is already fixed upstream. 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>